### PR TITLE
fix: standardise git urls so that SSH cloned repos are found

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -279,6 +279,12 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/git-url-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/git-url-parse/-/git-url-parse-9.0.0.tgz",
+      "integrity": "sha512-kA2RxBT/r/ZuDDKwMl+vFWn1Z0lfm1/Ik6Qb91wnSzyzCDa/fkM8gIOq6ruB7xfr37n6Mj5dyivileUVKsidlg==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -2960,6 +2966,23 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "git-up": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^5.0.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "requires": {
+        "git-up": "^4.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -3530,6 +3553,14 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-ssh": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "requires": {
+        "protocols": "^1.1.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -4044,6 +4075,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -4270,6 +4306,26 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parse-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "parse-url": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "normalize-url": "^3.3.0",
+        "parse-path": "^4.0.0",
+        "protocols": "^1.4.0"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4410,6 +4466,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
+    },
+    "protocols": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
     "@types/mz": "^2.7.0",
     "@types/rimraf": "^3.0.0",
     "express": "^4.17.1",
+    "git-url-parse": "^11.1.2",
     "mz": "^2.7.0",
     "rimraf": "^3.0.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.6",
+    "@types/git-url-parse": "^9.0.0",
     "@types/node": "^13.11.0",
     "@types/vscode": "^1.44.0",
     "@typescript-eslint/eslint-plugin": "^2.26.0",

--- a/src/Repository/searchClonedRepos.ts
+++ b/src/Repository/searchClonedRepos.ts
@@ -3,6 +3,7 @@ import { readdir } from 'mz/fs';
 import path from 'path';
 import { exec } from 'mz/child_process';
 import { Repository } from "./Repository";
+import GitUrlParse from "git-url-parse";
 
 // mz lib is a little old but does the job.
 // https://stackoverflow.com/a/37532027/10247962
@@ -30,10 +31,8 @@ async function getGitUrls(dirsPath: string[]): Promise<DirWithGitUrl[]> {
 
       // console.log([dirPath, result, regex]);
       if (regex) {
-        // Remove the .git the gitUrl may or not have (as our repo.htmlUrl don't have .git)
-        // This $ make it only remove the final .git, not removing .git from ie .github.io.git
-        let gitUrl = regex[0].replace(/\.git$/, '');
-        // console.log(gitUrl);
+        // Parse the git URL into a repository URL
+        let gitUrl = GitUrlParse(regex[0]).toString("https").replace('.git', '');
         dirsWithGitUrl.push({ gitUrl, dirPath });
       }
     }


### PR DESCRIPTION
Fixes https://github.com/SrBrahma/GitHub-Repository-Manager/issues/8,

This PR moves git urls to be standardised so that we can correctly resolve the repo to the clone