### PR TITLE
Fix: 'setAsFavorite' is already registered (duplicated command)

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
         "icon": "$(star)"
       },
       {
-        "command": "githubRepoMgr.commands.clonedRepos.setAsFavorite",
+        "command": "githubRepoMgr.commands.clonedRepos.unSetAsFavorite",
         "title": "Unset as Favorite",
         "icon": "$(star-full)"
       },

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
         "icon": "$(star)"
       },
       {
-        "command": "githubRepoMgr.commands.clonedRepos.unSetAsFavorite",
+        "command": "githubRepoMgr.commands.clonedRepos.unsetAsFavorite",
         "title": "Unset as Favorite",
         "icon": "$(star-full)"
       },


### PR DESCRIPTION
To see the bug:
Execute "F1 > Developer: Show Running Extensions."